### PR TITLE
feat: integrate Firebase Auth (Google/Apple/Email) with guards

### DIFF
--- a/lib/features/auth/auth_providers.dart
+++ b/lib/features/auth/auth_providers.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'auth_service_real.dart';
+
+/// FirebaseAuth 인스턴스
+final firebaseAuthProvider = Provider<FirebaseAuth>((_) => FirebaseAuth.instance);
+
+/// 실제 인증 서비스
+final authServiceProvider = Provider<AuthService>((ref) {
+  final auth = ref.read(firebaseAuthProvider);
+  return AuthService(auth);
+});
+
+/// 로그인 상태 스트림(User? 변동)
+final authUserStreamProvider = StreamProvider<User?>((ref) {
+  final auth = ref.read(firebaseAuthProvider);
+  return auth.authStateChanges();
+});

--- a/lib/features/auth/auth_service_real.dart
+++ b/lib/features/auth/auth_service_real.dart
@@ -1,0 +1,71 @@
+import 'dart:io' show Platform;
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+
+class AuthService {
+  final FirebaseAuth _auth;
+  AuthService(this._auth);
+
+  /// Firebase가 초기화되어 있고 네이티브 설정이 준비되었는지 가드
+  bool get isReady {
+    try {
+      // 값은 안 써도 접근만 되면 초기화된 것
+      _auth.app;
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<UserCredential> signInWithGoogle() async {
+    if (!isReady) {
+      throw StateError('Firebase 미설정: google-services.json / Info.plist 필요');
+    }
+    final google = GoogleSignIn(scopes: ['email']);
+    final account = await google.signIn();
+    if (account == null) {
+      throw StateError('사용자가 Google 로그인을 취소했습니다.');
+    }
+    final auth = await account.authentication;
+    final cred = GoogleAuthProvider.credential(
+      accessToken: auth.accessToken,
+      idToken: auth.idToken,
+    );
+    return _auth.signInWithCredential(cred);
+  }
+
+  Future<UserCredential> signInWithEmail(String email, String password) async {
+    if (!isReady) {
+      throw StateError('Firebase 미설정: 이메일/비밀번호 Auth 사용 불가');
+    }
+    try {
+      return await _auth.signInWithEmailAndPassword(email: email, password: password);
+    } on FirebaseAuthException catch (e) {
+      if (e.code == 'user-not-found') {
+        // MVP 정책: 없으면 자동 가입
+        return await _auth.createUserWithEmailAndPassword(email: email, password: password);
+      }
+      rethrow;
+    }
+  }
+
+  Future<UserCredential> signInWithApple() async {
+    if (!isReady) {
+      throw StateError('Firebase 미설정: iOS 설정/Capability 필요');
+    }
+    if (!Platform.isIOS) {
+      throw UnsupportedError('Apple 로그인은 iOS에서만 지원됩니다.');
+    }
+    final credential = await SignInWithApple.getAppleIDCredential(
+      scopes: [AppleIDAuthorizationScopes.email, AppleIDAuthorizationScopes.fullName],
+    );
+    final oauth = OAuthProvider('apple.com').credential(
+      idToken: credential.identityToken,
+      accessToken: credential.authorizationCode,
+    );
+    return _auth.signInWithCredential(oauth);
+  }
+
+  Future<void> signOut() => _auth.signOut();
+}

--- a/lib/features/onboarding/onboarding_page.dart
+++ b/lib/features/onboarding/onboarding_page.dart
@@ -1,26 +1,66 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+
+// 기존 더미 상태(흐름 유지용)
 import '../../core/constants/auth_state.dart';
+
+// ✅ 실연동 Auth 프로바이더/서비스
+import '../auth/auth_providers.dart';
+import '../auth/auth_service_real.dart';
 
 class OnboardingPage extends ConsumerWidget {
   const OnboardingPage({super.key});
-  Future<void> _dummyLogin(WidgetRef ref, BuildContext c) async {
-    await Future.delayed(const Duration(milliseconds: 800));
-    ref.read(authStateProvider.notifier).state = true;
-    if (c.mounted) GoRouter.of(c).go('/profile');
+
+  Future<void> _handle(
+    WidgetRef ref,
+    BuildContext c,
+    Future<void> Function(AuthService) action,
+  ) async {
+    final svc = ref.read(authServiceProvider);
+    try {
+      await action(svc);
+      // 로그인 성공 시 기존 더미 상태도 true로 동기화(기존 흐름 유지)
+      ref.read(authStateProvider.notifier).state = true;
+      if (c.mounted) GoRouter.of(c).go('/profile');
+    } catch (e) {
+      // 설정 누락/취소/오류 모두 사용자에게 안내
+      ScaffoldMessenger.of(c).showSnackBar(
+        SnackBar(content: Text('로그인 실패: $e')),
+      );
+    }
   }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(title: const Text('Onboarding')),
       body: Center(
-        child: Column(mainAxisSize: MainAxisSize.min, children: [
-          ElevatedButton(onPressed: () => _dummyLogin(ref, context), child: const Text('Continue with Apple')),
-          ElevatedButton(onPressed: () => _dummyLogin(ref, context), child: const Text('Continue with Google')),
-          ElevatedButton(onPressed: () => _dummyLogin(ref, context), child: const Text('Continue with Email')),
-        ]),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ElevatedButton(
+              onPressed: () => _handle(ref, context, (svc) async {
+                // iOS 외에서는 UnsupportedError 발생 → 가드 메시지로 안내됨
+                await svc.signInWithApple();
+              }),
+              child: const Text('Continue with Apple'),
+            ),
+            ElevatedButton(
+              onPressed: () => _handle(ref, context, (svc) async {
+                await svc.signInWithGoogle();
+              }),
+              child: const Text('Continue with Google'),
+            ),
+            ElevatedButton(
+              onPressed: () => _handle(ref, context, (svc) async {
+                // MVP용 임시 이메일 플로우(없으면 자동 가입 시도)
+                await svc.signInWithEmail('test@example.com', 'Passw0rd!');
+              }),
+              child: const Text('Continue with Email'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,4 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'app.dart';
 
-void main() => runApp(const ProviderScope(child: App()));
+// ✅ Firebase 초기화: 설정 파일이 없어도 크래시 없이 넘어가도록 가드 처리
+import 'package:firebase_core/firebase_core.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  try {
+    // 이후 라운드에서 google-services.json / GoogleService-Info.plist 연결 후 정상 초기화 예정
+    await Firebase.initializeApp();
+  } catch (e) {
+    // 설정이 없거나 환경이 준비되지 않으면 여기로 들어옴
+    // 앱 실행은 계속되도록 하고, 콘솔 경고만 남김
+    // ignore: avoid_print
+    print('⚠️ Firebase init skipped or deferred: $e');
+  }
+  runApp(const ProviderScope(child: App()));
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,9 @@ dependencies:
   firebase_analytics: ^11.3.0
   image_picker: ^1.1.2
   firebase_storage: ^12.3.0
+  google_sign_in: ^6.2.1
+  sign_in_with_apple: ^6.1.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
- Firebase.initializeApp 가드 추가 (설정 미완료 시 크래시 방지)
- Auth 서비스 추가: Google / Apple / Email flows
- Riverpod 프로바이더 추가: FirebaseAuth 인스턴스, 서비스, 유저 스트림
- 온보딩 버튼을 실연동 서비스로 연결 (오류/미설정은 SnackBar 안내)
